### PR TITLE
add support for generic NACK and PLI

### DIFF
--- a/src/compound.rs
+++ b/src/compound.rs
@@ -157,6 +157,8 @@ pub enum Packet<'a> {
     Rr(crate::ReceiverReport<'a>),
     Sdes(crate::Sdes<'a>),
     Sr(crate::SenderReport<'a>),
+    TransportFeedback(crate::TransportFeedback<'a>),
+    PayloadFeedback(crate::PayloadFeedback<'a>),
     Unknown(Unknown<'a>),
 }
 
@@ -201,6 +203,8 @@ impl<'a> RtcpPacketParser<'a> for Packet<'a> {
             Rr(this) => this.header_data(),
             Sdes(this) => this.header_data(),
             Sr(this) => this.header_data(),
+            TransportFeedback(this) => this.header_data(),
+            PayloadFeedback(this) => this.header_data(),
             Unknown(this) => this.header_data(),
         }
     }
@@ -298,6 +302,8 @@ pub enum PacketBuilder<'a> {
     Rr(crate::receiver::ReceiverReportBuilder),
     Sdes(crate::sdes::SdesBuilder<'a>),
     Sr(crate::sender::SenderReportBuilder),
+    TransportFeedback(crate::feedback::TransportFeedbackBuilder),
+    PayloadFeedback(crate::feedback::PayloadFeedbackBuilder),
     Unknown(UnknownBuilder<'a>),
 }
 
@@ -310,6 +316,8 @@ impl<'a> RtcpPacketWriter for PacketBuilder<'a> {
             Rr(this) => this.get_padding(),
             Sdes(this) => this.get_padding(),
             Sr(this) => this.get_padding(),
+            TransportFeedback(this) => this.get_padding(),
+            PayloadFeedback(this) => this.get_padding(),
             Unknown(this) => this.get_padding(),
         }
     }
@@ -322,6 +330,8 @@ impl<'a> RtcpPacketWriter for PacketBuilder<'a> {
             Rr(this) => this.calculate_size(),
             Sdes(this) => this.calculate_size(),
             Sr(this) => this.calculate_size(),
+            TransportFeedback(this) => this.calculate_size(),
+            PayloadFeedback(this) => this.calculate_size(),
             Unknown(this) => this.calculate_size(),
         }
     }
@@ -334,6 +344,8 @@ impl<'a> RtcpPacketWriter for PacketBuilder<'a> {
             Rr(this) => this.write_into_unchecked(buf),
             Sdes(this) => this.write_into_unchecked(buf),
             Sr(this) => this.write_into_unchecked(buf),
+            TransportFeedback(this) => this.write_into_unchecked(buf),
+            PayloadFeedback(this) => this.write_into_unchecked(buf),
             Unknown(this) => this.write_into_unchecked(buf),
         }
     }
@@ -472,6 +484,16 @@ impl_try_from!(
     crate::sender::SenderReport<'a>,
     crate::sender::SenderReportBuilder,
     Sr
+);
+impl_try_from!(
+    crate::feedback::TransportFeedback<'a>,
+    crate::feedback::TransportFeedbackBuilder,
+    TransportFeedback
+);
+impl_try_from!(
+    crate::feedback::PayloadFeedback<'a>,
+    crate::feedback::PayloadFeedbackBuilder,
+    PayloadFeedback
 );
 
 impl<'a> From<Unknown<'a>> for Packet<'a> {

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 
 pub mod nack;
 pub mod pli;
+pub mod rpsi;
 pub mod sli;
 
 #[derive(Debug, Default, PartialEq, Eq)]

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 
 pub mod nack;
 pub mod pli;
+pub mod sli;
 
 #[derive(Debug, Default, PartialEq, Eq)]
 pub struct FciFeedbackPacketType {

--- a/src/feedback/mod.rs
+++ b/src/feedback/mod.rs
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{
+    prelude::*,
+    utils::{pad_to_4bytes, parser, writer},
+    RtcpPacket, RtcpPacketParser, RtcpParseError, RtcpWriteError,
+};
+
+pub mod nack;
+pub mod pli;
+
+/// A parsed (Transport) Feedback packet as specified in RFC 4585.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TransportFeedback<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> RtcpPacket for TransportFeedback<'a> {
+    const MIN_PACKET_LEN: usize = 12;
+    const PACKET_TYPE: u8 = 205;
+}
+
+impl<'a> RtcpPacketParser<'a> for TransportFeedback<'a> {
+    fn parse(data: &'a [u8]) -> Result<Self, RtcpParseError> {
+        parser::check_packet::<Self>(data)?;
+        Ok(Self { data })
+    }
+
+    #[inline(always)]
+    fn header_data(&self) -> [u8; 4] {
+        self.data[..4].try_into().unwrap()
+    }
+}
+
+impl<'a> TransportFeedback<'a> {
+    pub fn builder(fci: impl FciBuilder<'static> + 'static) -> TransportFeedbackBuilder {
+        TransportFeedbackBuilder {
+            padding: 0,
+            sender_ssrc: 0,
+            media_ssrc: 0,
+            fci: Box::new(fci),
+        }
+    }
+
+    pub fn padding(&self) -> Option<u8> {
+        parser::parse_padding(self.data)
+    }
+
+    pub fn sender_ssrc(&self) -> u32 {
+        parser::parse_ssrc(self.data)
+    }
+
+    pub fn media_ssrc(&self) -> u32 {
+        parser::parse_ssrc(&self.data[4..])
+    }
+
+    pub fn parse_fci<F: FciParser<'a>>(&self) -> Result<F, RtcpParseError> {
+        F::parse(parser::parse_count(self.data), &self.data[12..])
+    }
+}
+
+/// TransportFeedback packet builder
+#[derive(Debug)]
+#[must_use = "The builder must be built to be used"]
+pub struct TransportFeedbackBuilder {
+    padding: u8,
+    sender_ssrc: u32,
+    media_ssrc: u32,
+    fci: Box<dyn FciBuilder<'static>>,
+}
+
+impl TransportFeedbackBuilder {
+    pub fn sender_ssrc(mut self, sender_ssrc: u32) -> Self {
+        self.sender_ssrc = sender_ssrc;
+        self
+    }
+
+    pub fn media_ssrc(mut self, media_ssrc: u32) -> Self {
+        self.media_ssrc = media_ssrc;
+        self
+    }
+
+    /// Sets the number of padding bytes to use for this TransportFeedback packet.
+    pub fn padding(mut self, padding: u8) -> Self {
+        self.padding = padding;
+        self
+    }
+}
+
+#[inline]
+fn fb_write_into<T: RtcpPacket>(
+    buf: &mut [u8],
+    sender_ssrc: u32,
+    media_ssrc: u32,
+    fci: &dyn FciBuilder,
+    padding: u8,
+) -> usize {
+    let fmt = fci.format();
+    assert!(fmt <= 0x1f);
+    let mut idx = writer::write_header_unchecked::<T>(padding, fmt, buf);
+
+    let mut end = idx;
+    end += 4;
+    buf[idx..end].copy_from_slice(&sender_ssrc.to_be_bytes());
+    idx = end;
+    end += 4;
+    buf[idx..end].copy_from_slice(&media_ssrc.to_be_bytes());
+    idx = end;
+
+    end += fci.write_into_unchecked(&mut buf[idx..]);
+
+    end += writer::write_padding_unchecked(padding, &mut buf[idx..]);
+
+    end
+}
+
+impl RtcpPacketWriter for TransportFeedbackBuilder {
+    /// Calculates the size required to write this TransportFeedback packet.
+    ///
+    /// Returns an error if:
+    ///
+    /// * The FCI data is too large
+    /// * The FCI fails to calculate a valid size
+    fn calculate_size(&self) -> Result<usize, RtcpWriteError> {
+        writer::check_padding(self.padding)?;
+
+        let fci_len = self
+            .fci
+            .as_ref()
+            .calculate_size()?;
+
+        Ok(TransportFeedback::MIN_PACKET_LEN + pad_to_4bytes(fci_len))
+    }
+
+    /// Write this TransportFeedback packet data into `buf` without any validity checks.
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the buf is not large enough.
+    #[inline]
+    fn write_into_unchecked(&self, buf: &mut [u8]) -> usize {
+        fb_write_into::<TransportFeedback>(
+            buf,
+            self.sender_ssrc,
+            self.media_ssrc,
+            self.fci.as_ref(),
+            self.padding,
+        )
+    }
+
+    fn get_padding(&self) -> Option<u8> {
+        if self.padding == 0 {
+            return None;
+        }
+
+        Some(self.padding)
+    }
+}
+
+/// A parsed (Transport) Feedback packet as specified in RFC 4585.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PayloadFeedback<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> RtcpPacket for PayloadFeedback<'a> {
+    const MIN_PACKET_LEN: usize = 12;
+    const PACKET_TYPE: u8 = 206;
+}
+
+impl<'a> RtcpPacketParser<'a> for PayloadFeedback<'a> {
+    fn parse(data: &'a [u8]) -> Result<Self, RtcpParseError> {
+        parser::check_packet::<Self>(data)?;
+        Ok(Self { data })
+    }
+
+    #[inline(always)]
+    fn header_data(&self) -> [u8; 4] {
+        self.data[..4].try_into().unwrap()
+    }
+}
+
+impl<'a> PayloadFeedback<'a> {
+    pub fn builder(fci: impl FciBuilder<'static> + 'static) -> PayloadFeedbackBuilder {
+        PayloadFeedbackBuilder {
+            padding: 0,
+            sender_ssrc: 0,
+            media_ssrc: 0,
+            fci: Box::new(fci),
+        }
+    }
+
+    pub fn padding(&self) -> Option<u8> {
+        parser::parse_padding(self.data)
+    }
+
+    pub fn sender_ssrc(&self) -> u32 {
+        parser::parse_ssrc(self.data)
+    }
+
+    pub fn media_ssrc(&self) -> u32 {
+        parser::parse_ssrc(&self.data[4..])
+    }
+
+    pub fn parse_fci<F: FciParser<'a>>(&self) -> Result<F, RtcpParseError> {
+        F::parse(parser::parse_count(self.data), &self.data[12..])
+    }
+}
+
+/// TransportFeedback packet builder
+#[derive(Debug)]
+#[must_use = "The builder must be built to be used"]
+pub struct PayloadFeedbackBuilder {
+    padding: u8,
+    sender_ssrc: u32,
+    media_ssrc: u32,
+    fci: Box<dyn FciBuilder<'static>>,
+}
+
+impl PayloadFeedbackBuilder {
+    pub fn sender_ssrc(mut self, sender_ssrc: u32) -> Self {
+        self.sender_ssrc = sender_ssrc;
+        self
+    }
+
+    pub fn media_ssrc(mut self, media_ssrc: u32) -> Self {
+        self.media_ssrc = media_ssrc;
+        self
+    }
+
+    /// Sets the number of padding bytes to use for this TransportFeedback packet.
+    pub fn padding(mut self, padding: u8) -> Self {
+        self.padding = padding;
+        self
+    }
+}
+
+impl RtcpPacketWriter for PayloadFeedbackBuilder {
+    /// Calculates the size required to write this PayloadFeedback packet.
+    ///
+    /// Returns an error if:
+    ///
+    /// * The FCI data is too large
+    /// * The FCI fails to calculate a valid size
+    fn calculate_size(&self) -> Result<usize, RtcpWriteError> {
+        writer::check_padding(self.padding)?;
+
+        let fci_len = self
+            .fci
+            .as_ref()
+            .calculate_size()?;
+
+        Ok(PayloadFeedback::MIN_PACKET_LEN + pad_to_4bytes(fci_len))
+    }
+
+    /// Write this TransportFeedback packet data into `buf` without any validity checks.
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// # Panic
+    ///
+    /// Panics if the buf is not large enough.
+    #[inline]
+    fn write_into_unchecked(&self, buf: &mut [u8]) -> usize {
+        fb_write_into::<PayloadFeedback>(
+            buf,
+            self.sender_ssrc,
+            self.media_ssrc,
+            self.fci.as_ref(),
+            self.padding,
+        )
+    }
+
+    fn get_padding(&self) -> Option<u8> {
+        if self.padding == 0 {
+            return None;
+        }
+
+        Some(self.padding)
+    }
+}
+
+pub trait FciParser<'a>: Sized {
+    /// Parse the provided FCI data
+    fn parse(format: u8, data: &'a [u8]) -> Result<Self, RtcpParseError>;
+}
+
+pub trait FciBuilder<'a>: RtcpPacketWriter {
+    /// The format field value to place in the RTCP header
+    fn format(&self) -> u8;
+}

--- a/src/feedback/nack.rs
+++ b/src/feedback/nack.rs
@@ -1,0 +1,267 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::collections::BTreeSet;
+
+use crate::{prelude::*, utils::u16_from_be_bytes};
+use crate::{RtcpParseError, RtcpWriteError};
+
+pub struct NackParserEntryIter<'a> {
+    parser: &'a Nack<'a>,
+    i: usize,
+    mask_i: usize,
+}
+
+impl<'a> NackParserEntryIter<'a> {
+    fn decode_entry(entry: &[u8]) -> (u16, u16) {
+        (
+            u16_from_be_bytes(&entry[0..2]),
+            u16_from_be_bytes(&entry[2..4]),
+        )
+    }
+}
+
+impl<'a> std::iter::Iterator for NackParserEntryIter<'a> {
+    type Item = u16;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if self.mask_i > 16 {
+                self.mask_i = 0;
+                self.i += 1;
+            }
+            let idx = self.i * 4;
+            if idx + 3 >= self.parser.data.len() {
+                return None;
+            }
+            let (base, mask) = NackParserEntryIter::decode_entry(&self.parser.data[idx..]);
+            if self.mask_i == 0 {
+                self.mask_i += 1;
+                return Some(base);
+            }
+
+            loop {
+                let mask = mask >> (self.mask_i - 1);
+                if (mask & 0x1) > 0 {
+                    self.mask_i += 1;
+                    let ret = base.wrapping_add(self.mask_i as u16 - 1);
+                    return Some(ret);
+                }
+                self.mask_i += 1;
+                if self.mask_i > 16 {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Generic NACK FCI information as specified in RFC 4585
+pub struct Nack<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Nack<'a> {
+    /// The list of RTP sequence numbers that is being NACKed.
+    pub fn entries(&self) -> impl Iterator<Item = u16> + '_ {
+        NackParserEntryIter {
+            parser: self,
+            i: 0,
+            mask_i: 0,
+        }
+    }
+
+    pub fn builder() -> NackBuilder {
+        NackBuilder::default()
+    }
+}
+
+impl<'a> FciParser<'a> for Nack<'a> {
+    fn parse(format: u8, data: &'a [u8]) -> Result<Self, RtcpParseError> {
+        if format != 1 {
+            return Err(RtcpParseError::WrongImplementation);
+        }
+        Ok(Self { data })
+    }
+}
+
+pub struct NackBuilderEntryIter<I: Iterator<Item = u16>> {
+    i: usize,
+    base_entry: Option<u16>,
+    seq_iter: I,
+    last_entry: u16,
+}
+
+fn encode_entry(base: u16, mask: u16) -> [u8; 4] {
+    [
+        ((base & 0xff00) >> 8) as u8,
+        (base & 0xff) as u8,
+        ((mask & 0xff00) >> 8) as u8,
+        (mask & 0xff) as u8,
+    ]
+}
+
+impl<I: Iterator<Item = u16>> std::iter::Iterator for NackBuilderEntryIter<I> {
+    type Item = [u8; 4];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut bitmask = 0;
+        for entry in self.seq_iter.by_ref() {
+            self.last_entry = entry;
+            if let Some(base) = self.base_entry {
+                let diff = entry.wrapping_sub(base);
+                if diff > 16 {
+                    // bitmask will overflow next iteration, return the current value
+                    let ret = encode_entry(base, bitmask);
+                    self.base_entry = Some(entry);
+                    return Some(ret);
+                }
+                if diff > 0 {
+                    bitmask |= 1 << (diff - 1);
+                }
+                self.i += 1;
+            } else {
+                // initial set up for the first value
+                self.base_entry = Some(entry);
+                self.i += 1;
+                continue;
+            }
+        }
+
+        if let Some(base) = self.base_entry {
+            // we need to output the final entry
+            let ret = encode_entry(base, bitmask);
+            self.base_entry = None;
+            return Some(ret);
+        }
+        None
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct NackBuilder {
+    rtp_seq: BTreeSet<u16>,
+}
+
+impl NackBuilder {
+    pub fn add_rtp_sequence(mut self, rtp_sequence: u16) -> Self {
+        self.rtp_seq.insert(rtp_sequence);
+        self
+    }
+
+    fn entries(&self) -> impl Iterator<Item = [u8; 4]> + '_ {
+        NackBuilderEntryIter {
+            i: 0,
+            base_entry: None,
+            seq_iter: self.rtp_seq.iter().copied(),
+            last_entry: 0,
+        }
+    }
+}
+
+impl<'a> FciBuilder<'a> for NackBuilder {
+    fn format(&self) -> u8 {
+        1
+    }
+}
+
+impl RtcpPacketWriter for NackBuilder {
+    fn calculate_size(&self) -> Result<usize, RtcpWriteError> {
+        let entries = self.entries().count();
+        if entries > u16::MAX as usize - 2 {
+            return Err(RtcpWriteError::TooManyNack);
+        }
+        Ok(entries * 4)
+    }
+
+    fn write_into_unchecked(&self, buf: &mut [u8]) -> usize {
+        let mut idx = 0;
+        let mut end = idx;
+
+        for entry in self.entries() {
+            end += 4;
+            buf[idx..end].copy_from_slice(&entry);
+            idx = end;
+        }
+        end
+    }
+
+    fn get_padding(&self) -> Option<u8> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feedback::TransportFeedback;
+
+    fn nack_build_parse_n_consecutive_timestamps(start: u16, n: u16, fci: &[u8]) {
+        nack_build_parse_n_m_timestamps(start, n, 1, fci)
+    }
+
+    fn nack_build_parse_n_m_timestamps(start: u16, n: u16, m: u16, fci: &[u8]) {
+        assert!(n > 1);
+        let r = (n + 1) % m;
+        let req_len = TransportFeedback::MIN_PACKET_LEN + ((n - r + 16) / 17 * 4) as usize;
+        let mut data = vec![0; req_len];
+        let mut expected = vec![0; req_len];
+        const TEMPLATE: [u8; 12] = [
+            0x81, 0xcd, 0x00, 0x00, 0x98, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba,
+        ];
+        expected[0..12].copy_from_slice(&TEMPLATE);
+        expected[3] = (req_len / 4 - 1) as u8;
+        expected[12..12 + fci.len()].copy_from_slice(fci);
+        let nack = {
+            let mut fci = Nack::builder();
+            for i in (0..=n - 1).step_by(m as usize) {
+                fci = fci.add_rtp_sequence(start + i);
+            }
+            TransportFeedback::builder(fci)
+                .sender_ssrc(0x98765432)
+                .media_ssrc(0x10fedcba)
+        };
+        assert_eq!(nack.calculate_size().unwrap(), req_len);
+        let len = nack.write_into(&mut data).unwrap();
+        assert_eq!(len, req_len);
+        assert_eq!(data, expected);
+
+        let fb = TransportFeedback::parse(&data).unwrap();
+        assert_eq!(fb.sender_ssrc(), 0x98765432);
+        assert_eq!(fb.media_ssrc(), 0x10fedcba);
+        let nack = fb.parse_fci::<Nack>().unwrap();
+        let mut nack_iter = nack.entries();
+        for i in (0..=n - 1).step_by(m as usize) {
+            assert_eq!(nack_iter.next(), Some(0x1234 + i));
+        }
+        assert_eq!(nack_iter.next(), None);
+    }
+
+    #[test]
+    fn nack_build_parse_2_consecutive_timestamps() {
+        nack_build_parse_n_consecutive_timestamps(0x1234, 2, &[0x12, 0x34, 0x00, 0x01]);
+    }
+
+    #[test]
+    fn nack_build_parse_16_consecutive_timestamps() {
+        nack_build_parse_n_consecutive_timestamps(0x1234, 16, &[0x12, 0x34, 0x7f, 0xff]);
+    }
+
+    #[test]
+    fn nack_build_parse_17_consecutive_timestamps() {
+        nack_build_parse_n_consecutive_timestamps(0x1234, 17, &[0x12, 0x34, 0xff, 0xff]);
+    }
+
+    #[test]
+    fn nack_build_parse_18_consecutive_timestamps() {
+        nack_build_parse_n_consecutive_timestamps(
+            0x1234,
+            18,
+            &[0x12, 0x34, 0xff, 0xff, 0x12, 0x45, 0x00, 0x00],
+        );
+    }
+
+    #[test]
+    fn nack_build_parse_12_2_timestamps() {
+        nack_build_parse_n_m_timestamps(0x1234, 12, 2, &[0x12, 0x34, 0x02, 0b1010_1010]);
+    }
+}

--- a/src/feedback/nack.rs
+++ b/src/feedback/nack.rs
@@ -2,6 +2,7 @@
 
 use std::collections::BTreeSet;
 
+use crate::feedback::FciFeedbackPacketType;
 use crate::{prelude::*, utils::u16_from_be_bytes};
 use crate::{RtcpParseError, RtcpWriteError};
 
@@ -76,10 +77,10 @@ impl<'a> Nack<'a> {
 }
 
 impl<'a> FciParser<'a> for Nack<'a> {
-    fn parse(format: u8, data: &'a [u8]) -> Result<Self, RtcpParseError> {
-        if format != 1 {
-            return Err(RtcpParseError::WrongImplementation);
-        }
+    const PACKET_TYPE: FciFeedbackPacketType = FciFeedbackPacketType::TRANSPORT;
+    const FCI_FORMAT: u8 = 1;
+
+    fn parse(data: &'a [u8]) -> Result<Self, RtcpParseError> {
         Ok(Self { data })
     }
 }
@@ -161,6 +162,10 @@ impl NackBuilder {
 impl<'a> FciBuilder<'a> for NackBuilder {
     fn format(&self) -> u8 {
         1
+    }
+
+    fn supports_feedback_type(&self) -> FciFeedbackPacketType {
+        FciFeedbackPacketType::TRANSPORT
     }
 }
 

--- a/src/feedback/pli.rs
+++ b/src/feedback/pli.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::{prelude::*, RtcpParseError, RtcpWriteError};
+
+/// Picture Loss Information as specified in RFC 4585
+#[derive(Debug)]
+pub struct Pli<'a> {
+    _data: &'a [u8],
+}
+
+impl<'a> Pli<'a> {
+    pub fn builder() -> PliBuilder {
+        PliBuilder {}
+    }
+}
+
+impl<'a> FciParser<'a> for Pli<'a> {
+    fn parse(format: u8, data: &'a [u8]) -> Result<Self, RtcpParseError> {
+        if format != 1 {
+            return Err(RtcpParseError::WrongImplementation);
+        }
+        if !data.is_empty() {
+            return Err(RtcpParseError::TooLarge {
+                expected: 0,
+                actual: data.len(),
+            });
+        }
+        Ok(Self { _data: data })
+    }
+}
+
+#[derive(Debug)]
+pub struct PliBuilder {}
+
+impl<'a> FciBuilder<'a> for PliBuilder {
+    fn format(&self) -> u8 {
+        1
+    }
+}
+
+impl RtcpPacketWriter for PliBuilder {
+    fn calculate_size(&self) -> Result<usize, RtcpWriteError> {
+        Ok(0)
+    }
+
+    fn write_into_unchecked(&self, _buf: &mut [u8]) -> usize {
+        0
+    }
+
+    fn get_padding(&self) -> Option<u8> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feedback::PayloadFeedback;
+
+    #[test]
+    fn pli_build_parse() {
+        const REQ_LEN: usize = PayloadFeedback::MIN_PACKET_LEN;
+        let mut data = [0; REQ_LEN];
+        let pli = {
+            let fci = Pli::builder();
+            PayloadFeedback::builder(fci)
+                .sender_ssrc(0x98765432)
+                .media_ssrc(0x10fedcba)
+        };
+        assert_eq!(pli.calculate_size().unwrap(), REQ_LEN);
+        let len = pli.write_into(&mut data).unwrap();
+        assert_eq!(len, REQ_LEN);
+        assert_eq!(
+            data,
+            [0x81, 0xce, 0x00, 0x02, 0x98, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba,]
+        );
+
+        let fb = PayloadFeedback::parse(&data).unwrap();
+
+        assert_eq!(fb.sender_ssrc(), 0x98765432);
+        assert_eq!(fb.media_ssrc(), 0x10fedcba);
+        let _pli = fb.parse_fci::<Pli>().unwrap();
+    }
+
+    #[test]
+    fn pli_parse_with_data() {
+        let pli = PayloadFeedback::parse(&[
+            0x81, 0xce, 0x00, 0x03, 0x98, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba, 0x00, 0x00,
+            0x00, 0x00,
+        ])
+        .unwrap();
+        assert!(matches!(
+            pli.parse_fci::<Pli>(),
+            Err(RtcpParseError::TooLarge {
+                expected: 0,
+                actual: 4
+            })
+        ));
+    }
+}

--- a/src/feedback/rpsi.rs
+++ b/src/feedback/rpsi.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::borrow::Cow;
+
+use crate::feedback::FciFeedbackPacketType;
+use crate::utils::pad_to_4bytes;
+use crate::{prelude::*, RtcpParseError, RtcpWriteError};
+
+#[derive(Debug)]
+pub struct Rpsi<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Rpsi<'a> {
+    pub fn builder() -> RpsiBuilder<'a> {
+        RpsiBuilder::default()
+    }
+
+    pub fn payload_type(&self) -> u8 {
+        self.data[1] & 0x7f
+    }
+
+    pub fn bit_string(&self) -> (&[u8], usize) {
+        let padding_bytes = self.padding_bytes();
+        let padding_bits = self.data[0] as usize - padding_bytes * 8;
+        (&self.data[2..self.data.len() - padding_bytes], padding_bits)
+    }
+
+    fn padding_bytes(&self) -> usize {
+        (self.data[0] / 8) as usize
+    }
+}
+
+impl<'a> FciParser<'a> for Rpsi<'a> {
+    const PACKET_TYPE: FciFeedbackPacketType = FciFeedbackPacketType::PAYLOAD;
+    const FCI_FORMAT: u8 = 3;
+
+    fn parse(data: &'a [u8]) -> Result<Self, RtcpParseError> {
+        if data.len() < 4 {
+            return Err(RtcpParseError::Truncated {
+                expected: 4,
+                actual: data.len(),
+            });
+        }
+        let ret = Self { data };
+        if ret.padding_bytes() > data.len() - 2 {
+            return Err(RtcpParseError::Truncated {
+                expected: ret.padding_bytes() + 2,
+                actual: data.len(),
+            });
+        }
+
+        Ok(ret)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RpsiBuilder<'a> {
+    payload_type: u8,
+    native_bit_string: Cow<'a, [u8]>,
+    native_bit_overrun: u8,
+}
+
+impl<'a> RpsiBuilder<'a> {
+    pub fn payload_type(mut self, payload_type: u8) -> Self {
+        self.payload_type = payload_type;
+        self
+    }
+
+    pub fn native_data(mut self, data: impl Into<Cow<'a, [u8]>>, bit_overrun: u8) -> Self {
+        self.native_bit_string = data.into();
+        self.native_bit_overrun = bit_overrun;
+        self
+    }
+
+    pub fn native_data_owned(
+        self,
+        data: impl Into<Cow<'a, [u8]>>,
+        bit_overrun: u8,
+    ) -> RpsiBuilder<'static> {
+        RpsiBuilder {
+            payload_type: self.payload_type,
+            native_bit_string: data.into().into_owned().into(),
+            native_bit_overrun: bit_overrun,
+        }
+    }
+}
+
+impl<'a> FciBuilder<'a> for RpsiBuilder<'a> {
+    fn format(&self) -> u8 {
+        Rpsi::FCI_FORMAT
+    }
+
+    fn supports_feedback_type(&self) -> FciFeedbackPacketType {
+        FciFeedbackPacketType::PAYLOAD
+    }
+}
+
+impl<'a> RtcpPacketWriter for RpsiBuilder<'a> {
+    fn calculate_size(&self) -> Result<usize, RtcpWriteError> {
+        if self.payload_type > 127 {
+            return Err(RtcpWriteError::PayloadTypeInvalid);
+        }
+        if self.native_bit_overrun > 8
+            || self.native_bit_string.is_empty() && self.native_bit_overrun > 0
+        {
+            return Err(RtcpWriteError::PaddingBitsTooLarge);
+        }
+        Ok(pad_to_4bytes(self.native_bit_string.len()))
+    }
+
+    fn write_into_unchecked(&self, buf: &mut [u8]) -> usize {
+        let end = pad_to_4bytes(2 + self.native_bit_string.len());
+        let trailing_bits =
+            8 * (end - self.native_bit_string.len() - 2) + self.native_bit_overrun as usize;
+        buf[0] = trailing_bits as u8;
+        buf[1] = self.payload_type;
+        let mut idx = 2 + self.native_bit_string.len();
+        buf[2..idx].copy_from_slice(&self.native_bit_string);
+        if !self.native_bit_string.is_empty() {
+            let mut bitmask = 0;
+            let mut trailing_bits = self.native_bit_overrun;
+            while trailing_bits > 0 {
+                bitmask = (bitmask << 1) | 1;
+                trailing_bits -= 1;
+            }
+            buf[idx - 1] &= !bitmask;
+        }
+        while idx < end {
+            buf[idx] = 0;
+            idx += 1;
+        }
+        idx
+    }
+
+    fn get_padding(&self) -> Option<u8> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feedback::PayloadFeedback;
+
+    #[test]
+    fn rpsi_build_parse() {
+        const REQ_LEN: usize = PayloadFeedback::MIN_PACKET_LEN + 4;
+        let mut data = [0; REQ_LEN];
+        let rpsi = {
+            let data = &[0xf0];
+            let fci = Rpsi::builder()
+                .payload_type(96)
+                .native_data_owned(data.as_ref(), 4);
+            PayloadFeedback::builder(fci)
+                .sender_ssrc(0x98765432)
+                .media_ssrc(0x10fedcba)
+        };
+        assert_eq!(rpsi.calculate_size().unwrap(), REQ_LEN);
+        let len = rpsi.write_into(&mut data).unwrap();
+        assert_eq!(len, REQ_LEN);
+        assert_eq!(
+            data,
+            [
+                0x83, 0xce, 0x00, 0x03, 0x98, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba, 0x0c, 0x60,
+                0xf0, 0x00
+            ]
+        );
+
+        let fb = PayloadFeedback::parse(&data).unwrap();
+
+        assert_eq!(fb.sender_ssrc(), 0x98765432);
+        assert_eq!(fb.media_ssrc(), 0x10fedcba);
+        let rpsi = fb.parse_fci::<Rpsi>().unwrap();
+        assert_eq!(rpsi.payload_type(), 96);
+        assert_eq!(rpsi.bit_string(), ([0xf0].as_ref(), 4));
+    }
+}

--- a/src/feedback/sli.rs
+++ b/src/feedback/sli.rs
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use crate::feedback::FciFeedbackPacketType;
+use crate::{prelude::*, RtcpParseError, RtcpWriteError};
+
+#[derive(Debug)]
+pub struct Sli<'a> {
+    data: &'a [u8],
+}
+
+impl<'a> Sli<'a> {
+    pub fn lost_macroblocks(&self) -> impl Iterator<Item = MacroBlockEntry> + '_ {
+        MacroBlockIter {
+            data: self.data,
+            i: 0,
+        }
+    }
+
+    pub fn builder() -> SliBuilder {
+        SliBuilder { lost_mbs: vec![] }
+    }
+}
+
+impl<'a> FciParser<'a> for Sli<'a> {
+    const PACKET_TYPE: FciFeedbackPacketType = FciFeedbackPacketType::PAYLOAD;
+    const FCI_FORMAT: u8 = 2;
+
+    fn parse(data: &'a [u8]) -> Result<Self, RtcpParseError> {
+        if data.len() < 4 {
+            return Err(RtcpParseError::Truncated {
+                expected: 4,
+                actual: data.len(),
+            });
+        }
+        Ok(Self { data })
+    }
+}
+
+struct MacroBlockIter<'a> {
+    data: &'a [u8],
+    i: usize,
+}
+
+impl<'a> Iterator for MacroBlockIter<'a> {
+    type Item = MacroBlockEntry;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i + 3 > self.data.len() {
+            return None;
+        }
+        let data = [
+            self.data[self.i],
+            self.data[self.i + 1],
+            self.data[self.i + 2],
+            self.data[self.i + 3],
+        ];
+        self.i += 4;
+        Some(MacroBlockEntry::decode(data))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+pub struct MacroBlockEntry {
+    start: u16,
+    count: u16,
+    picture_id: u8,
+}
+
+impl MacroBlockEntry {
+    fn encode(&self) -> [u8; 4] {
+        let mut ret = [0; 4];
+        ret[0] = ((self.start & 0x1fe0) >> 5) as u8;
+        ret[1] = ((self.start & 0x1f) << 3) as u8 | ((self.count & 0x1c00) >> 10) as u8;
+        ret[2] = ((self.count & 0x03fc) >> 2) as u8;
+        ret[3] = ((self.count & 0x0003) as u8) << 6 | self.picture_id & 0x3f;
+        ret
+    }
+
+    fn decode(data: [u8; 4]) -> Self {
+        let start = (data[0] as u16) << 5 | (data[1] as u16 & 0xf8) >> 3;
+        let count =
+            ((data[1] & 0x07) as u16) << 10 | (data[2] as u16) << 2 | (data[3] as u16 & 0xc0) >> 6;
+        let picture_id = data[3] & 0x3f;
+        Self {
+            start,
+            count,
+            picture_id,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SliBuilder {
+    lost_mbs: Vec<MacroBlockEntry>,
+}
+
+impl SliBuilder {
+    pub fn add_lost_macroblock(
+        mut self,
+        start_macroblock: u16,
+        count_macroblocks: u16,
+        picture_id: u8,
+    ) -> Self {
+        self.lost_mbs.push(MacroBlockEntry {
+            start: start_macroblock,
+            count: count_macroblocks,
+            picture_id,
+        });
+        self
+    }
+}
+
+impl<'a> FciBuilder<'a> for SliBuilder {
+    fn format(&self) -> u8 {
+        2
+    }
+
+    fn supports_feedback_type(&self) -> FciFeedbackPacketType {
+        FciFeedbackPacketType::PAYLOAD
+    }
+}
+
+impl RtcpPacketWriter for SliBuilder {
+    fn calculate_size(&self) -> Result<usize, RtcpWriteError> {
+        Ok(4 * self.lost_mbs.len())
+    }
+
+    fn write_into_unchecked(&self, buf: &mut [u8]) -> usize {
+        let mut idx = 0;
+        for entry in self.lost_mbs.iter() {
+            let encoded = entry.encode();
+            buf[idx] = encoded[0];
+            buf[idx + 1] = encoded[1];
+            buf[idx + 2] = encoded[2];
+            buf[idx + 3] = encoded[3];
+            idx += 4;
+        }
+        idx
+    }
+
+    fn get_padding(&self) -> Option<u8> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::feedback::PayloadFeedback;
+
+    #[test]
+    fn macroblock_entries() {
+        let mut start = 0;
+        loop {
+            let mut count = 0;
+            loop {
+                for picture_id in 0..=0x3f {
+                    let mbe = MacroBlockEntry {
+                        start,
+                        count,
+                        picture_id,
+                    };
+                    let other = MacroBlockEntry::decode(mbe.encode());
+                    assert_eq!(mbe, other);
+                }
+                count = (count << 1) | 1;
+                if count > 0x1fff {
+                    break;
+                }
+            }
+            start = (start << 1) | 1;
+            if start > 0x1fff {
+                break;
+            }
+        }
+    }
+
+    #[test]
+    fn sli_build_parse() {
+        const REQ_LEN: usize = PayloadFeedback::MIN_PACKET_LEN + 4;
+        let mut data = [0; REQ_LEN];
+        let sli = {
+            let fci = Sli::builder().add_lost_macroblock(0x1234, 0x0987, 0x25);
+            PayloadFeedback::builder(fci)
+                .sender_ssrc(0x98765432)
+                .media_ssrc(0x10fedcba)
+        };
+        assert_eq!(sli.calculate_size().unwrap(), REQ_LEN);
+        let len = sli.write_into(&mut data).unwrap();
+        assert_eq!(len, REQ_LEN);
+        assert_eq!(
+            data,
+            [
+                0x82, 0xce, 0x00, 0x03, 0x98, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba, 0x91, 0xa2,
+                0x61, 0xe5
+            ]
+        );
+
+        let fb = PayloadFeedback::parse(&data).unwrap();
+
+        assert_eq!(fb.sender_ssrc(), 0x98765432);
+        assert_eq!(fb.media_ssrc(), 0x10fedcba);
+        let sli = fb.parse_fci::<Sli>().unwrap();
+        let mut mb_iter = sli.lost_macroblocks();
+        assert_eq!(
+            mb_iter.next(),
+            Some(MacroBlockEntry {
+                start: 0x1234,
+                count: 0x987,
+                picture_id: 0x25
+            })
+        );
+        assert_eq!(mb_iter.next(), None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,6 +227,14 @@ pub enum RtcpWriteError {
     /// Feedback packet does not support this FCI data.
     #[error("Wrong feedback packet type for the provided FCI data")]
     FciWrongFeedbackPacketType,
+
+    /// Payload type value out of range.
+    #[error("The RTP payload value is not a valid value")]
+    PayloadTypeInvalid,
+
+    /// Payload type value out of range.
+    #[error("The amount of padding bits are greater than the size of the data")]
+    PaddingBitsTooLarge,
 }
 
 impl From<RtcpParseError> for RtcpWriteError {
@@ -261,6 +269,7 @@ pub use bye::{Bye, ByeBuilder};
 pub use compound::{Compound, CompoundBuilder, Packet, PacketBuilder, Unknown, UnknownBuilder};
 pub use feedback::nack::{Nack, NackBuilder};
 pub use feedback::pli::{Pli, PliBuilder};
+pub use feedback::rpsi::{Rpsi, RpsiBuilder};
 pub use feedback::sli::{Sli, SliBuilder};
 pub use feedback::{
     FciBuilder, FciParser, PayloadFeedback, PayloadFeedbackBuilder, TransportFeedback,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,10 @@ pub enum RtcpWriteError {
     /// Number of NACK's will not fit within a single RTCP packet.
     #[error("The number of NACK entries will not fit inside a RTCP packet.")]
     TooManyNack,
+
+    /// Feedback packet does not support this FCI data.
+    #[error("Wrong feedback packet type for the provided FCI data")]
+    FciWrongFeedbackPacketType,
 }
 
 impl From<RtcpParseError> for RtcpWriteError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,6 +261,7 @@ pub use bye::{Bye, ByeBuilder};
 pub use compound::{Compound, CompoundBuilder, Packet, PacketBuilder, Unknown, UnknownBuilder};
 pub use feedback::nack::{Nack, NackBuilder};
 pub use feedback::pli::{Pli, PliBuilder};
+pub use feedback::sli::{Sli, SliBuilder};
 pub use feedback::{
     FciBuilder, FciParser, PayloadFeedback, PayloadFeedbackBuilder, TransportFeedback,
     TransportFeedbackBuilder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,6 +215,14 @@ pub enum RtcpWriteError {
     /// Non-last Compound packet padding defined.
     #[error("Non-last Compound packet padding defined")]
     NonLastCompoundPacketPadding,
+
+    /// Feedback packet does not have any FCI defined.
+    #[error("Feedback packet does not contain any FCI data")]
+    MissingFci,
+
+    /// Number of NACK's will not fit within a single RTCP packet.
+    #[error("The number of NACK entries will not fit inside a RTCP packet.")]
+    TooManyNack,
 }
 
 impl From<RtcpParseError> for RtcpWriteError {
@@ -237,6 +245,7 @@ impl From<RtcpParseError> for RtcpWriteError {
 mod app;
 mod bye;
 mod compound;
+mod feedback;
 mod receiver;
 mod report_block;
 mod sdes;
@@ -246,11 +255,20 @@ pub mod utils;
 pub use app::{App, AppBuilder};
 pub use bye::{Bye, ByeBuilder};
 pub use compound::{Compound, CompoundBuilder, Packet, PacketBuilder, Unknown, UnknownBuilder};
+pub use feedback::nack::{Nack, NackBuilder};
+pub use feedback::pli::{Pli, PliBuilder};
+pub use feedback::{
+    FciBuilder, FciParser, PayloadFeedback, PayloadFeedbackBuilder, TransportFeedback,
+    TransportFeedbackBuilder,
+};
 pub use receiver::{ReceiverReport, ReceiverReportBuilder};
 pub use report_block::{ReportBlock, ReportBlockBuilder};
 pub use sdes::{Sdes, SdesBuilder, SdesChunk, SdesChunkBuilder, SdesItem, SdesItemBuilder};
 pub use sender::{SenderReport, SenderReportBuilder};
 
 pub mod prelude {
-    pub use super::{RtcpPacketParser, RtcpPacketParserExt, RtcpPacketWriter, RtcpPacketWriterExt};
+    pub use super::{
+        FciBuilder, FciParser, RtcpPacket, RtcpPacketParser, RtcpPacketParserExt, RtcpPacketWriter,
+        RtcpPacketWriterExt,
+    };
 }


### PR DESCRIPTION
Uses slightly different feedback packets with only the pt value being different.

The FCI data can be implemented externally as required.

As specified in RFC 4585.