### PR TITLE
feedback: allow stack or heap allocated FciBuilders

### DIFF
--- a/src/compound.rs
+++ b/src/compound.rs
@@ -308,8 +308,8 @@ pub enum PacketBuilder<'a> {
     Rr(crate::receiver::ReceiverReportBuilder),
     Sdes(crate::sdes::SdesBuilder<'a>),
     Sr(crate::sender::SenderReportBuilder),
-    TransportFeedback(crate::feedback::TransportFeedbackBuilder),
-    PayloadFeedback(crate::feedback::PayloadFeedbackBuilder),
+    TransportFeedback(crate::feedback::TransportFeedbackBuilder<'a>),
+    PayloadFeedback(crate::feedback::PayloadFeedbackBuilder<'a>),
     Unknown(UnknownBuilder<'a>),
 }
 
@@ -493,12 +493,12 @@ impl_try_from!(
 );
 impl_try_from!(
     crate::feedback::TransportFeedback<'a>,
-    crate::feedback::TransportFeedbackBuilder,
+    crate::feedback::TransportFeedbackBuilder<'a>,
     TransportFeedback
 );
 impl_try_from!(
     crate::feedback::PayloadFeedback<'a>,
-    crate::feedback::PayloadFeedbackBuilder,
+    crate::feedback::PayloadFeedbackBuilder<'a>,
     PayloadFeedback
 );
 

--- a/src/feedback/fir.rs
+++ b/src/feedback/fir.rs
@@ -150,7 +150,7 @@ mod tests {
         let mut data = [0; REQ_LEN];
         let fir = {
             let fci = Fir::builder().add_ssrc(0xfedcba98, 0x30);
-            PayloadFeedback::builder(fci)
+            PayloadFeedback::builder_owned(fci)
                 .sender_ssrc(0x98765432)
                 .media_ssrc(0)
         };

--- a/src/feedback/sli.rs
+++ b/src/feedback/sli.rs
@@ -181,7 +181,7 @@ mod tests {
         let mut data = [0; REQ_LEN];
         let sli = {
             let fci = Sli::builder().add_lost_macroblock(0x1234, 0x0987, 0x25);
-            PayloadFeedback::builder(fci)
+            PayloadFeedback::builder_owned(fci)
                 .sender_ssrc(0x98765432)
                 .media_ssrc(0x10fedcba)
         };
@@ -211,5 +211,25 @@ mod tests {
             })
         );
         assert_eq!(mb_iter.next(), None);
+    }
+
+    #[test]
+    fn sli_build_ref() {
+        const REQ_LEN: usize = PayloadFeedback::MIN_PACKET_LEN + 4;
+        let mut data = [0; REQ_LEN];
+        let fci = Sli::builder().add_lost_macroblock(0x1234, 0x0987, 0x25);
+        let sli = PayloadFeedback::builder(&fci)
+            .sender_ssrc(0x98765432)
+            .media_ssrc(0x10fedcba);
+        assert_eq!(sli.calculate_size().unwrap(), REQ_LEN);
+        let len = sli.write_into(&mut data).unwrap();
+        assert_eq!(len, REQ_LEN);
+        assert_eq!(
+            data,
+            [
+                0x82, 0xce, 0x00, 0x03, 0x98, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba, 0x91, 0xa2,
+                0x61, 0xe5
+            ]
+        );
     }
 }


### PR DESCRIPTION
This PR makes it possible to avoid heap allocation when a `TransportFeedbackBuilder` or `PayloadFeedbackBuilder` doesn't escape the lifetime of its `FciBuilder`.