### PR TITLE
ci: update artifact action to v4

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -37,7 +37,7 @@ jobs:
           token: ${{secrets.CODECOV_TOKEN}}
 
       - name: Archive code coverage results
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: code-coverage-report
           path: cobertura.xml


### PR DESCRIPTION
https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/