### PR TITLE
add Send & Sync bounds to RtcpPacketWriter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,7 +76,7 @@ impl<'a, T: RtcpPacketParser<'a>> RtcpPacketParserExt<'a> for T {}
 /// Note: this trait must remain [object-safe].
 ///
 /// [object-safe]: https://doc.rust-lang.org/reference/items/traits.html#object-safety
-pub trait RtcpPacketWriter: std::fmt::Debug {
+pub trait RtcpPacketWriter: std::fmt::Debug + Send + Sync {
     /// Calculates the size required to write this RTCP packet.
     ///
     /// Also performs validity checks.

--- a/src/sdes.rs
+++ b/src/sdes.rs
@@ -690,7 +690,7 @@ mod tests {
             + pad_to_4bytes(
                 2 + "cname".len()
                     + 2
-                    + "François".as_bytes().len()
+                    + "François".len()
                     + 3
                     + "priv-prefix".len()
                     + "priv-value".len(),
@@ -772,7 +772,7 @@ mod tests {
 
         const REQ_LEN: usize = Sdes::MIN_PACKET_LEN
             + SdesChunk::MIN_LEN
-            + pad_to_4bytes(2 + "cname".len() + 2 + "François".as_bytes().len())
+            + pad_to_4bytes(2 + "cname".len() + 2 + "François".len())
             + SdesChunk::MIN_LEN
             + pad_to_4bytes(2 + "user@host".len() + 2 + "+33678901234".len());
 


### PR DESCRIPTION
Without these bounds the `PacketBuilder` and `CompoundBuilder` types are `!Send`, since they store trait objects of `FciBuilder` and `RtcpPacketWriter` respectively.

Closes #14