### PR TITLE
ci: update coverage job versions

### DIFF
--- a/.github/workflows/rust-coverage.yml
+++ b/.github/workflows/rust-coverage.yml
@@ -13,17 +13,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install stable toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           override: true
 
       - name: Install cargo-tarpaulin
-        uses: actions-rs/cargo@v1
+        uses: taiki-e/cache-cargo-install-action@v2
         with:
-          command: install
-          args: '--version 0.23.1 cargo-tarpaulin'
+          tool: cargo-tarpaulin@0.32
 
       - name: Run cargo-tarpaulin
         uses: actions-rs/cargo@v1
@@ -32,7 +31,7 @@ jobs:
           args: '--out Xml -- --test-threads 1'
 
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3.1.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{secrets.CODECOV_TOKEN}}
 


### PR DESCRIPTION
- cargo tarpaulin to 0.32
- codecov action to v5